### PR TITLE
Refactor 예외 메시지 수정

### DIFF
--- a/routes/authRouter.js
+++ b/routes/authRouter.js
@@ -133,7 +133,7 @@ authRouter.post('/logout', (req, res) => {
     const sessionId = req.cookies.session_id;
 
     if (sessionId === undefined) {
-        throw new ErrorWrapper(400, 4000, '유효하지 않은 요청입니다', null);
+        throw new ErrorWrapper(401, 4001, '인증이 필요합니다', null);
     }
 
     authController.logout(res, sessionId);
@@ -144,7 +144,7 @@ authRouter.delete('/withdrawal', (req, res) => {
     const sessionId = req.cookies.session_id;
 
     if (sessionId === undefined) {
-        throw new ErrorWrapper(401, 4001, '유효하지 않은 요청입니다', null);
+        throw new ErrorWrapper(401, 4001, '인증이 필요합니다', null);
     }
 
     const userId = getLoggedInUser(sessionId).id;


### PR DESCRIPTION
REST API 문서를 따르도록 변경

로그아웃, 회원탈퇴의 경우 session_id 가 필요한데 이게 없음은 유효하지 않은 요청 이전에 인증 실패로 다루는게 좋을 것 같아 변경합니다.