### PR TITLE
Fix date 가 string 일 시 Date 객체로 변환하는 로직 추가 #5

### DIFF
--- a/utils/dateTimeUtils.js
+++ b/utils/dateTimeUtils.js
@@ -1,4 +1,9 @@
 export const formatDateTime = date => {
     const pad = num => String(num).padStart(2, '0');
+    
+    if (typeof date === 'string') {
+        date = new Date(date);
+    }
+    
     return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 };


### PR DESCRIPTION
json 에서 역직렬화할 경우 문자열로 만들어져 Date 의 메소드를 사용할 시 예외가 발생해 추가했습니다.

역직렬화 과정에서 Date로 만들 수 있으나 이 편이 간단하여 택했습니다.

this closes #5 