### PR TITLE
회원탈퇴 시 게시글이 삭제되지 않는 문제 해결

### DIFF
--- a/controller/authController.js
+++ b/controller/authController.js
@@ -11,7 +11,6 @@ import { postDao } from '../dao/postDaos.js';
 import { commentDao } from '../dao/commentDaos.js';
 import { viewHistoryDao } from '../dao/viewHistoryDaos.js';
 import { postLikeDao } from '../dao/postLikeDaos.js';
-import { postController } from './postController.js';
 
 // Data Model
 import { User } from '../model/user.js';
@@ -106,10 +105,7 @@ class AuthController {
     }
 
     async withdraw(res, sessionId, userId) {
-        const posts = postDao.findAllByUserId(userId);
-        posts.forEach(post => {
-            postController.deletePost(post.id);
-        });
+        postDao.deleteAllByUserId(userId);
         commentDao.deleteCommentsByUserId(userId);
         postLikeDao.deleteAllByUserId(userId);
         viewHistoryDao.deleteViewHistoriesByUserId(userId);

--- a/dao/postDaos.js
+++ b/dao/postDaos.js
@@ -59,7 +59,7 @@ class InMemoryPostDao extends IPostDao {
     }
 
     findAllByUserId(userId) {
-        return this.posts.filter(post => post.userId === userId);
+        return this.posts.filter(post => post.authorId === userId);
     }
 
     createPost(post) {
@@ -107,6 +107,14 @@ class InMemoryPostDao extends IPostDao {
     deletePost(post) {
         const postIdx = this.posts.indexOf(post);
         this.posts.splice(postIdx, 1);
+        flush(postJsonFilename, this.posts);
+    }
+
+    deleteAllByUserId(userId) {
+        const posts = this.findAllByUserId(userId);
+        posts.forEach(post => {
+            this.deletePost(post.id);
+        });
         flush(postJsonFilename, this.posts);
     }
 }

--- a/dao/postDaos.js
+++ b/dao/postDaos.js
@@ -113,7 +113,7 @@ class InMemoryPostDao extends IPostDao {
     deleteAllByUserId(userId) {
         const posts = this.findAllByUserId(userId);
         posts.forEach(post => {
-            this.deletePost(post.id);
+            this.deletePost(post);
         });
         flush(postJsonFilename, this.posts);
     }


### PR DESCRIPTION
- 첫 번째 문제는 deletePost 를 dao 것이 아닌 비즈니스 로직이 있는 PostController 의 것을 사용한 것이 문제였습니다.
순수한 데이터에 접근하는 dao 는 권한을 따지지 않지만 PostController 의 것은 접근 권한을 따집니다.

- 두 번째 문제는 deletePost 시 post 를 받아야하는데 post의 id 를 던져버려 문제가 발생했습니다.